### PR TITLE
chore(pre-align): align heading structure (4 docs) with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,8 +1,16 @@
+<!-- pre-align:aligned sig=0acd3d23fa1f -->
+
+<a id="network-service-gateway-console-user-guide"></a>
+
 ## Network > Service Gateway > Console User Guide
 
 This guides describes how to use the **Service Gateway** service from the console.
 
+<a id="service-gateway"></a>
+
 ## Service Gateway
+
+<a id="create-a-service-gateway"></a>
 
 ### Create a Service Gateway
 
@@ -23,9 +31,13 @@ To create a service gateway, use the following steps:
     * Selection is only possible at creation time, and changes are not supported.
     > [Note] It is only enabled on services that allow selection.
 
+<a id="view-a-service-gateway"></a>
+
 ### View a Service Gateway
 
 You can check the created service gateway on the **Network > Service Gateway** page. If you select a service gateway, the service gateway information appears at the bottom.
+
+<a id="modify-a-service-gateway"></a>
 
 ### Modify a Service Gateway
 
@@ -34,17 +46,73 @@ A service gateway can be modified as follows. You can only change the **Name** a
 1. Go to **Network > Service Gateway**.
 2. Click **Change Service Gateway** and change items on the change screen.
 
+<a id="delete-a-service-gateway"></a>
+
 ### Delete a Service Gateway
 
 To delete a service gateway, select the service gateway you want to delete in the **Network > Service Gateway** page and click the **Delete Service Gateway** button.
 
+<a id="section-1"></a>
+
+## Custom endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1"></a>
+
+### Create a Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2"></a>
+
+### Get a Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3"></a>
+
+### Change Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4"></a>
+
+### Delete a Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5"></a>
+
+### Reissue Service Name
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6"></a>
+
+### Manage Allowed Projects
+
+<!-- TODO: translate body -->
+
+<a id="section-1-7"></a>
+
+### Check usage status
+
+<!-- TODO: translate body -->
+
+<a id="use-a-service-gateway"></a>
+
 ## Use a Service Gateway
+
+<a id="check-the-service-gateway-ip"></a>
 
 ### Check the Service Gateway IP
 
 1. Go to **Network > Service Gateway**.
 2. Check the **IP address** in the list of service gateways.<br>
    When the VM Instance accesses this IP address, it is connected to the service that the service gateway is connected to.
+
+<a id="connect-to-the-service-gateway"></a>
 
 ### Connect to the Service Gateway
 
@@ -67,9 +135,13 @@ For example, if the IP address of the created service gateway is `192.168.1.42`,
 
             ~# wget https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_8222a22c22244badbf876dcd521f3f98/test-obs/test_file.txt
 
+<a id="example-of-using-object-storage-from-a-service-gateway"></a>
+
 ## Example of Using Object Storage from a Service Gateway
 
 Content related to **object storage** are described only at the level required for explaining the example. For details on how to use object storage, refer to **User Guide > Storage > Object Storage**.
+
+<a id="example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway"></a>
 
 ### Create a Service Gateway
 
@@ -80,6 +152,8 @@ To use the **Object Storage API**, you must obtain an **authentication token**. 
 2. Choose the **IaaS API Identity** service to create a service gateway.<br>
    A service gateway for obtaining the authentication token.
 3. Check the IP addresses on the two service gateways that have been created.
+
+<a id="edit-the-etchosts-file"></a>
 
 ### Edit the /etc/hosts File
 
@@ -92,6 +166,8 @@ For example, if the IP address of the service gateway created by selecting **Obj
 192.168.1.42	api-identity-infrastructure.nhncloudservice.com
 192.168.1.57	kr1-api-object-storage.nhncloudservice.com
 ```
+
+<a id="obtain-the-authentication-token"></a>
 
 ### Obtain the Authentication Token
 
@@ -114,6 +190,8 @@ For example, if the IP address of the service gateway created by selecting **Obj
   In the response below, the value of the `access.token.id` entry is the authentication token. The authentication token is valid until the time in `access.token.expires`.
 
             {"access":{"token":{"id":"gAAAAABiVnmCOJVJhh1W2eXGo3aL0eaZxXmd-SMDMIE3zmip2lXy6eH0BlZAlTZBG20dWEm7TF4zi4YIOTKnc6yKh_wqZsyxgMWKkpVNShzE-k6GaSThBP54QeUePSjC2t-R10X6G4xL_Wecl-V-lV-bnOfVo6Ccpz6rv9eLYJnbJw7KrIMSSiY","expires":"2022-04-13T19:19:30Z","tenant":{"id":"2fda9d4b8821111192ff23841198e2e6","name":"tTMgSSSF","groupId":"XXj2zkH7777modGU","description":"","enabled":true,"project_domain":"NORMAL","swift":true},"issued_at":"2022-04-13T07:32:14.000441"},"serviceCatalog":[{"endpoints":[{"region":"KR1","publicURL":"https://api-identity.infrastructure.cloud.toast.com/v2.0"}],"type":"identity","name":"keystone"},{"endpoints":[{"region":"KR2","publicURL":"https://kr2-api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"},{"region":"KR1","publicURL":"https://api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"}],"type":"object-store","name":"swift"}],"user":{"id":"80884888887b45dbaf9b815117130671","username":"5111111c-b111-4b11-b11b-01111f81111f","name":"5211122c-bfc4-4115-b11b-05b52f84
+
+<a id="use-the-object-storage-api"></a>
 
 ### Use the Object Storage API
 

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=d880ee4f6445 -->
+
+<a id="network-service-gateway-overview"></a>
+
 ## Network > Service Gateway > Overview
 
 The **Service Gateway** service allows you to use the **services** of NHN Cloud outside the **VPC** without using a **floating IP** and having the traffic going through the internet. The **service** selected when **creating the service gateway** and the automatically assigned IP maintain a one-to-one relationship. In the **VPC**, you can use the target **service** safely through the NHN Cloud's internal network using the **service gateway**'s IP address.
+
+<a id="main-features"></a>
 
 ### Main Features
 
@@ -10,9 +16,17 @@ The **Service Gateway** service allows you to use the **services** of NHN Cloud 
 * When the VM Instance in the VPC communicates with the IP address of the service gateway, it communicates with the service associated with the service gateway.
 * This service is currently only available in the Korea (Pangyo) and Korea (Pyeongchon) regions, and will be supported by other regions gradually.
 
+<a id="provided-services"></a>
+
 ### Provided Services
 
 If you need to access NHN Cloud's services from a VM Instance in the VPC without going through the internet, create a service gateway by selecting a service provided by the service gateway.
 For details on how to use each service, refer to the [Service Gateway > Console User Guide](/Network/Service%20Gateway/en/console-guide/). 
 
 For the services offered, see the [**Service Endpoints**](/Network/Service%20Gateway/ko/service-endpoint/). The services offered will be expanded.
+<a id="network-service-gateway-overview-1"></a>
+
+### Custom endpoint
+
+<!-- TODO: translate body -->
+

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -1,3 +1,6 @@
+<!-- pre-align:aligned sig=0f36aac40dbd -->
+
+<a id="network-service-gateway-api-v2-guide"></a>
 
 ## Network > Service Gateway > API v2 Guide
 
@@ -11,7 +14,11 @@ For Service Gateway APIs, the `network` type endpoint is used. For more details,
 
 In each API response, you may find fields that are not specified within this guide. Those fields are for NHN Cloud internal usage, so refrain from using them because they may be changed without prior notice.
 
+<a id="service-gateway"></a>
+
 ## Service Gateway
+
+<a id="get-a-list-of-service-gateways"></a>
 
 ### Get a List of Service Gateways
 
@@ -19,6 +26,8 @@ In each API response, you may find fields that are not specified within this gui
 GET /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
+
+<a id="request"></a>
 
 #### Request
 This API does not require a request body.
@@ -35,6 +44,8 @@ This API does not require a request body.
 | fixed_ip| Query | String | - | The IP address of the service gateway to retrieve |
 include_gateway_identity| Query | Boolean | - | Whether to use fixed NAT IP address |
 
+
+<a id="response"></a>
 
 #### Response
 
@@ -78,12 +89,16 @@ include_gateway_identity| Query | Boolean | - | Whether to use fixed NAT IP addr
 </details>
 
 ---
+<a id="get-a-service-gateway"></a>
+
 ### Get a Service Gateway
 
 ```
 GET /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-service-gateway-request"></a>
 
 #### Request
 This API does not require a request body.
@@ -92,6 +107,8 @@ This API does not require a request body.
 |---|---|---|---|---|
 | tokenId | Header | String | O | Token ID |
 | serviceGatewayId | URL | UUID | O | The ID of the service gateway |
+
+<a id="get-a-service-gateway-response"></a>
 
 #### Response
 
@@ -140,12 +157,16 @@ This API does not require a request body.
 </details>
 
 ---
+<a id="create-a-service-gateway"></a>
+
 ### Create a Service Gateway
 
 ```
 POST /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
+
+<a id="create-a-service-gateway-request"></a>
 
 #### Request
 
@@ -179,6 +200,8 @@ X-Auth-Token: {tokenId}
 }
 ```
 </details>
+
+<a id="create-a-service-gateway-response"></a>
 
 #### Response
 
@@ -228,12 +251,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="modify-a-service-gateway"></a>
+
 ### Modify a Service Gateway
 
 ```
 PUT /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="modify-a-service-gateway-request"></a>
 
 #### Request
 
@@ -256,6 +283,8 @@ X-Auth-Token: {tokenId}
 }
 ```
 </details>
+
+<a id="modify-a-service-gateway-response"></a>
 
 #### Response
 
@@ -305,12 +334,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="delete-a-service-gateway"></a>
+
 ### Delete a Service Gateway
 
 ```
 DELETE /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="delete-a-service-gateway-request"></a>
 
 #### Request
 This API does not require a request body.
@@ -320,6 +353,8 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | serviceGatewayId | URL | UUID | O | The ID of the service gateway |
 
+
+<a id="delete-a-service-gateway-response"></a>
 
 #### Response
 Stops the specified node group.
@@ -333,7 +368,11 @@ Stops the specified node group.
 
 
 
+<a id="service-endpoint"></a>
+
 ## Service Endpoint
+
+<a id="get-a-list-of-service-endpoints"></a>
 
 ### Get a List of Service Endpoints
 
@@ -341,6 +380,8 @@ Stops the specified node group.
 GET /v2.0/gateways/serviceendpoints/
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-list-of-service-endpoints-request"></a>
 
 #### Request
 This API does not require a request body.
@@ -352,6 +393,8 @@ This API does not require a request body.
 | display_name | Query | UUID | - | The name of the service endpoint to retrieve |
 
 
+
+<a id="get-a-list-of-service-endpoints-response"></a>
 
 #### Response
 
@@ -381,12 +424,16 @@ This API does not require a request body.
 </details>
 
 ---
+<a id="get-a-service-endpoint"></a>
+
 ### Get a Service Endpoint
 
 ```
 GET /v2.0/gateways/serviceendpoints/{seerviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-service-endpoint-request"></a>
 
 #### Request
 This API does not require a request body.
@@ -395,6 +442,8 @@ This API does not require a request body.
 |---|---|---|---|---|
 | tokenId | Header | String | O | Token ID |
 | serviceEndpointId | URL | UUID | O | Service endpoint ID |
+
+<a id="get-a-service-endpoint-response"></a>
 
 #### Response
 
@@ -422,3 +471,237 @@ This API does not require a request body.
 </details>
 
 ---
+<a id="section-1"></a>
+
+## Custom endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1"></a>
+
+### View Custom Endpoint List
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2"></a>
+
+### Get a Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3"></a>
+
+### Create Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4"></a>
+
+### Modify Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5"></a>
+
+### Delete Custom Endpoint
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6"></a>
+
+### Reissue the Service Name
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-2"></a>
+
+## Allowed Projects
+
+<!-- TODO: translate body -->
+
+<a id="section-2-1"></a>
+
+### View Allowed Project List
+
+<!-- TODO: translate body -->
+
+<a id="section-2-1-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-2-1-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-2-2"></a>
+
+### View Allowed Projects
+
+<!-- TODO: translate body -->
+
+<a id="section-2-2-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-2-2-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-2-3"></a>
+
+### Create an Allowed Project
+
+<!-- TODO: translate body -->
+
+<a id="section-2-3-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-2-3-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-2-4"></a>
+
+### Modify Allowed Projects
+
+<!-- TODO: translate body -->
+
+<a id="section-2-4-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-2-4-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-2-5"></a>
+
+### Delete an Allowed Project
+
+<!-- TODO: translate body -->
+
+<a id="section-2-5-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-2-5-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+
+<a id="section-3"></a>
+
+## Usage Status
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1"></a>
+
+### View Usage Status List
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1-1"></a>
+
+#### Request
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1-2"></a>
+
+#### Response
+
+<!-- TODO: translate body -->
+

--- a/en/service-endpoint.md
+++ b/en/service-endpoint.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=1d1c35e9431e -->
+
+<a id="network-service-gateway-service-endpoint"></a>
+
 ## Network > Service Gateway > Service Endpoint
 
 A list of services that can communicate with the NHN Cloud internal network using Service Gateway and the endpoints for each service.
+
+<a id="region-code"></a>
 
 ### Region Code
 
@@ -12,6 +18,8 @@ A list of services that can communicate with the NHN Cloud internal network usin
 | Korea (Pyeongchon) | kr2 |
 | Korea (Gwangju) | kr3 |
 | Japan (Tokyo) | jp1 |
+
+<a id="service-gateway-integration-services"></a>
 
 ### Service Gateway Integration Services
 

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,8 +1,16 @@
+<!-- pre-align:aligned sig=0acd3d23fa1f -->
+
+<a id="network-service-gateway-console-user-guide"></a>
+
 ## Network > Service Gateway > コンソール使用ガイド
 
 コンソールで**Service Gateway**サービスを使用する方法を説明します。
 
+<a id="service-gateway"></a>
+
 ## サービスゲートウェイ
+
+<a id="create-a-service-gateway"></a>
 
 ### サービスゲートウェイの作成
 
@@ -19,9 +27,13 @@
     > [参考]入力するIPアドレスは選択したサブネットのCIDR範囲内にある必要があります。
 7. **サービス**を選択します。サービスゲートウェイに割り当てられたIPでアクセスすると、選択したサービスと接続されます。
 
+<a id="view-a-service-gateway"></a>
+
 ### サービスゲートウェイの照会
 
 作成したサービスゲートウェイは**Network > Service Gateway**画面で確認できます。サービスゲートウェイを選択すると、下部にサービスゲートウェイ情報が表示されます。
+
+<a id="modify-a-service-gateway"></a>
 
 ### サービスゲートウェイの変更
 
@@ -30,17 +42,73 @@
 1. **Network > Service Gateway**に移動します。
 2. **サービスゲートウェイ変更**ボタンをクリックし、変更画面で項目を変更します。
 
+<a id="delete-a-service-gateway"></a>
+
 ### サービスゲートウェイの削除
 
 サービスゲートウェイを削除するには**Network > Service Gateway**画面で削除するサービスゲートウェイを選択し、**サービスゲートウェイ削除**ボタンをクリックします。
 
+<a id="section-1"></a>
+
+## カスタムエンドポイント
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1"></a>
+
+### カスタムエンドポイントの作成
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2"></a>
+
+### カスタムエンドポイントの照会
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3"></a>
+
+### ユーザー定義エンドポイントの変更
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4"></a>
+
+### カスタムエンドポイントの削除
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5"></a>
+
+### サービス名の再発行
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6"></a>
+
+### 許可プロジェクトの管理
+
+<!-- TODO: translate body -->
+
+<a id="section-1-7"></a>
+
+### 使用状況の確認
+
+<!-- TODO: translate body -->
+
+<a id="use-a-service-gateway"></a>
+
 ## サービスゲートウェイの使用
+
+<a id="check-the-service-gateway-ip"></a>
 
 ### サービスゲートウェイIPの確認
 
 1. **Network > Service Gateway**に移動します。
 2. サービスゲートウェイリストで**IPアドレス**を確認します。<br>
   このVM InstanceからこのIPアドレスに接続すると、サービスゲートウェイが接続しているサービスに接続されます。
+
+<a id="connect-to-the-service-gateway"></a>
 
 ### サービスゲートウェイ接続
 
@@ -63,9 +131,13 @@
 
             ~# wget https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_8222a22c22244badbf876dcd521f3f98/test-obs/test_file.txt
 
+<a id="example-of-using-object-storage-from-a-service-gateway"></a>
+
 ## サービスゲートウェイでオブジェクトストレージを使用する例
 
 **オブジェクトストレージ**に関連する内容は、例を説明するための水準でのみ記述します。オブジェクトストレージの詳細については**ユーザーガイド > Storage > Oject Storage**を参照してください。
+
+<a id="example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway"></a>
 
 ### サービスゲートウェイの作成
 
@@ -76,6 +148,8 @@
 2. **IaaS API Identity**サービスを選択してサービスゲートウェイを作成します。<br>
  認証トークン(token)を発行するためのサービスゲートウェイです。
 3. 作成された2つのサービスゲートウェイでIPアドレスを確認します。
+
+<a id="edit-the-etchosts-file"></a>
 
 ### /etc/hostsファイルの編集
 
@@ -88,6 +162,8 @@
 192.168.1.42	api-identity-infrastructure.nhncloudservice.com
 192.168.1.57	kr1-api-object-storage.nhncloudservice.com
 ```
+
+<a id="obtain-the-authentication-token"></a>
 
 ### 認証トークンの発行
 
@@ -108,6 +184,8 @@
  以下のレスポンスで`access.token.id`項目の値が認証トークンです。`access.token.expires`に記録された時間まで認証トークンが有効です。
 
             {"access":{"token":{"id":"gAAAAABiVnmCOJVJhh1W2eXGo3aL0eaZxXmd-SMDMIE3zmip2lXy6eH0BlZAlTZBG20dWEm7TF4zi4YIOTKnc6yKh_wqZsyxgMWKkpVNShzE-k6GaSThBP54QeUePSjC2t-R10X6G4xL_Wecl-V-lV-bnOfVo6Ccpz6rv9eLYJnbJw7KrIMSSiY","expires":"2022-04-13T19:19:30Z","tenant":{"id":"2fda9d4b8821111192ff23841198e2e6","name":"tTMgSSSF","groupId":"XXj2zkH7777modGU","description":"","enabled":true,"project_domain":"NORMAL","swift":true},"issued_at":"2022-04-13T07:32:14.000441"},"serviceCatalog":[{"endpoints":[{"region":"KR1","publicURL":"https://api-identity.infrastructure.cloud.toast.com/v2.0"}],"type":"identity","name":"keystone"},{"endpoints":[{"region":"KR2","publicURL":"https://kr2-api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"},{"region":"KR1","publicURL":"https://api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"}],"type":"object-store","name":"swift"}],"user":{"id":"80884888887b45dbaf9b815117130671","username":"5111111c-b111-4b11-b11b-01111f81111f","name":"5211122c-bfc4-4115-b11b-05b52f84
+
+<a id="use-the-object-storage-api"></a>
 
 ### オブジェクトストレージAPIの使用
 

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=d880ee4f6445 -->
+
+<a id="network-service-gateway-overview"></a>
+
 ## Network > Service Gateway > 概要
 
 **Service Gateway**サービスを利用すると**Floating IP**を使用せず、トラフィックがインターネットを経由しなくても**VPC**外部のNHN Cloudの**サービス**を利用できます。**サービスゲートウェイ作成**時に選択された**サービス**と自動的に割り当てられたIPは1:1接続関係を維持し、**VPC**では**サービスゲートウェイ**のIPを利用してNHN Cloudの内部ネットワークを経由して対象**サービス**を安全に利用できます。
+
+<a id="main-features"></a>
 
 ### 主な機能
 
@@ -10,9 +16,17 @@
 * VPCのVM InstanceからサービスゲートウェイのIPアドレスに通信すると、サービスゲートウェイに接続されたサービスと通信されます。
 * 現在は韓国(パンギョ)、韓国(ピョンチョン)リージョンにのみ提供されます。今後、他のリージョンもサポートする予定です。
 
+<a id="provided-services"></a>
+
 ### 提供サービス
 
 VPCのVM Instanceからインターネットを経由せずにNHN Cloudのサービスにアクセスする必要がある場合は、サービスゲートウェイで提供されるサービスを選択してサービスゲートウェイを作成します。
 詳細な使い方は[Service Gateway > コンソール使用ガイド](/Network/Service%20Gateway/ja/console-guide/)を参照してください。
 
 提供サービス提供[**サービスエンドポイント**](/Network/Service%20Gateway/ja/service-endpoint/)ポイントをご覧ください。提供されるサービスは徐々に拡大していく予定です。
+<a id="network-service-gateway-overview-1"></a>
+
+### カスタムエンドポイント
+
+<!-- TODO: translate body -->
+

--- a/ja/public-api.md
+++ b/ja/public-api.md
@@ -1,3 +1,6 @@
+<!-- pre-align:aligned sig=0f36aac40dbd -->
+
+<a id="network-service-gateway-api-v2-guide"></a>
 
 ## Network > Service Gateway > API v2ガイド
 
@@ -11,7 +14,11 @@ NHN Cloud Networkサービスは、API呼び出し時の認証/認可のため�
 
 APIレスポンスにガイドに記載されていないフィールドが表示される場合があります。このようなフィールドは、NHN Cloudの内部用途に使用され、事前告知なしに変更される可能性があるため、使用しないでください。
 
+<a id="service-gateway"></a>
+
 ## サービスゲートウェイ
+
+<a id="get-a-list-of-service-gateways"></a>
 
 ### サービスゲートウェイリスト表示
 
@@ -19,6 +26,8 @@ APIレスポンスにガイドに記載されていないフィールドが表�
 GET /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
+
+<a id="request"></a>
 
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
@@ -34,6 +43,8 @@ X-Auth-Token: {tokenId}
 | port_id | Query | UUID | - | 照会するサービスゲートウェイポートID |
 | fixed_ip| Query | String | - | 照会するサービスゲートウェイIPアドレス |
 
+
+<a id="response"></a>
 
 #### レスポンス
 
@@ -75,12 +86,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="get-a-service-gateway"></a>
+
 ### サービスゲートウェイ表示
 
 ```
 GET /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-service-gateway-request"></a>
 
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
@@ -89,6 +104,8 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | トークンID |
 | serviceGatewayId | URL | UUID | O | サービスゲートウェイID |
+
+<a id="get-a-service-gateway-response"></a>
 
 #### レスポンス
 
@@ -135,12 +152,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="create-a-service-gateway"></a>
+
 ### サービスゲートウェイを作成する
 
 ```
 POST /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
+
+<a id="create-a-service-gateway-request"></a>
 
 #### リクエスト
 
@@ -173,6 +194,8 @@ X-Auth-Token: {tokenId}
 }
 ```
 </details>
+
+<a id="create-a-service-gateway-response"></a>
 
 #### レスポンス
 
@@ -220,12 +243,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="modify-a-service-gateway"></a>
+
 ### サービスゲートウェイを修正する
 
 ```
 PUT /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="modify-a-service-gateway-request"></a>
 
 #### リクエスト
 
@@ -248,6 +275,8 @@ X-Auth-Token: {tokenId}
 }
 ```
 </details>
+
+<a id="modify-a-service-gateway-response"></a>
 
 #### レスポンス
 
@@ -295,12 +324,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="delete-a-service-gateway"></a>
+
 ### サービスゲートウェイを削除する
 
 ```
 DELETE /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="delete-a-service-gateway-request"></a>
 
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
@@ -310,6 +343,8 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | serviceGatewayId | URL | UUID | O | サービスゲートウェイID |
 
+
+<a id="delete-a-service-gateway-response"></a>
 
 #### レスポンス
 このAPIはレスポンス本文を返しません。
@@ -323,7 +358,11 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="service-endpoint"></a>
+
 ## サービスエンドポイント
+
+<a id="get-a-list-of-service-endpoints"></a>
 
 ### サービスエンドポイントリスト表示
 
@@ -331,6 +370,8 @@ X-Auth-Token: {tokenId}
 GET /v2.0/gateways/serviceendpoints/
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-list-of-service-endpoints-request"></a>
 
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
@@ -342,6 +383,8 @@ X-Auth-Token: {tokenId}
 | display_name | Query | UUID | - | 照会するサービスエンドポイントの名前 |
 
 
+
+<a id="get-a-list-of-service-endpoints-response"></a>
 
 #### レスポンス
 
@@ -369,12 +412,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="get-a-service-endpoint"></a>
+
 ### サービスエンドポイント表示
 
 ```
 GET /v2.0/gateways/serviceendpoints/{seerviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-service-endpoint-request"></a>
 
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
@@ -383,6 +430,8 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | トークンID |
 | serviceEndpointId | URL | UUID | O | サービスエンドポイントID |
+
+<a id="get-a-service-endpoint-response"></a>
 
 #### レスポンス
 
@@ -408,3 +457,237 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="section-1"></a>
+
+## カスタムエンドポイント
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1"></a>
+
+### カスタムエンドポイントリスト表示
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-1-1-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2"></a>
+
+### カスタムエンドポイント表示
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-1-2-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3"></a>
+
+### カスタムエンドポイントの作成
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-1-3-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4"></a>
+
+### カスタムエンドポイントの修正
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-1-4-2"></a>
+
+#### 応答
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5"></a>
+
+### カスタムエンドポイントの削除
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-1-5-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6"></a>
+
+### サービス名の再発行
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-1-6-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-2"></a>
+
+## 許可プロジェクト
+
+<!-- TODO: translate body -->
+
+<a id="section-2-1"></a>
+
+### 許可プロジェクトリスト表示
+
+<!-- TODO: translate body -->
+
+<a id="section-2-1-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-2-1-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-2-2"></a>
+
+### 許可プロジェクト表示
+
+<!-- TODO: translate body -->
+
+<a id="section-2-2-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-2-2-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-2-3"></a>
+
+### 許可プロジェクトの作成
+
+<!-- TODO: translate body -->
+
+<a id="section-2-3-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-2-3-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-2-4"></a>
+
+### 許可プロジェクトの変更
+
+<!-- TODO: translate body -->
+
+<a id="section-2-4-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-2-4-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-2-5"></a>
+
+### 許可プロジェクトの削除
+
+<!-- TODO: translate body -->
+
+<a id="section-2-5-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-2-5-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+
+<a id="section-3"></a>
+
+## 使用状況
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1"></a>
+
+### 使用状況リスト表示
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1-1"></a>
+
+#### リクエスト
+
+<!-- TODO: translate body -->
+
+<a id="section-3-1-2"></a>
+
+#### レスポンス
+
+<!-- TODO: translate body -->
+

--- a/ja/service-endpoint.md
+++ b/ja/service-endpoint.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=1d1c35e9431e -->
+
+<a id="network-service-gateway-service-endpoint"></a>
+
 ## Network > Service Gateway > 連動サービスエンドポイント
 
 サービスゲートウェイを利用してNHN Cloudの内部ネットワークと通信できるサービスリスト及び各サービスのエンドポイントです。
+
+<a id="region-code"></a>
 
 ### リージョンコード
 
@@ -12,6 +18,8 @@
 | 韓国(ピョンチョン) | kr2 |
 | 韓国(光州) | kr3 |
 | 日本(東京) | jp1 |
+
+<a id="service-gateway-integration-services"></a>
 
 ### サービスゲートウェイ連動サービス
 

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,8 +1,16 @@
+<!-- pre-align:aligned sig=0acd3d23fa1f -->
+
+<a id="network-service-gateway-console-user-guide"></a>
+
 ## Network > Service Gateway > 콘솔 사용 가이드
 
 콘솔에서 **Service Gateway** 서비스를 사용하는 방법을 설명합니다.
 
+<a id="service-gateway"></a>
+
 ## 서비스 게이트웨이
+
+<a id="create-a-service-gateway"></a>
 
 ### 서비스 게이트웨이 생성
 
@@ -26,9 +34,13 @@
     * 생성 시에만 선택이 가능하며 변경은 지원하지 않습니다.
     > [참고] 선택이 가능한 서비스에서만 활성화됩니다.
 
+<a id="view-a-service-gateway"></a>
+
 ### 서비스 게이트웨이 조회
 
 생성한 서비스 게이트웨이는 **Network > Service Gateway** 화면에서 확인할 수 있습니다. 서비스 게이트웨이를 선택하면 하단에 서비스 게이트웨이 정보가 나타납니다. 연결 유형이 **사용자 정의 엔드포인트**인 경우, 상세 정보의 **연결 대상**에서 엔드포인트의 표시 이름과 식별자를 확인할 수 있습니다.
+
+<a id="modify-a-service-gateway"></a>
 
 ### 서비스 게이트웨이 변경
 
@@ -37,13 +49,19 @@
 1. **Network > Service Gateway**로 이동합니다.
 2. **서비스 게이트웨이 변경** 버튼을 클릭한 후 변경 화면에서 원하는 항목을 변경합니다.
 
+<a id="delete-a-service-gateway"></a>
+
 ### 서비스 게이트웨이 삭제
 
 서비스 게이트웨이를 삭제하려면 **Network > Service Gateway** 화면에서 삭제할 서비스 게이트웨이를 선택하고 **서비스 게이트웨이 삭제** 버튼을 클릭합니다.
 
+<a id="section-1"></a>
+
 ## 사용자 정의 엔드포인트
 
 사용자 정의 엔드포인트는 사용자가 자신의 리소스(로드 밸런서)를 엔드포인트로 게시하여, 다른 프로젝트에서 서비스 게이트웨이로 연결할 수 있도록 공유하는 기능입니다. 게시자는 공유용 **서비스 이름(service_name)**을 발급받아 연결을 허용할 대상에게 전달하고, 허용 프로젝트를 직접 관리합니다.
+
+<a id="section-1-1"></a>
 
 ### 사용자 정의 엔드포인트 생성
 
@@ -62,9 +80,13 @@
 
 > [참고] 사용자 정의 엔드포인트는 프로젝트당 기본 5개까지 생성할 수 있습니다.
 
+<a id="section-1-2"></a>
+
 ### 사용자 정의 엔드포인트 조회
 
 **사용자 정의 엔드포인트** 탭에서 생성한 엔드포인트 목록을 확인할 수 있습니다. 엔드포인트를 선택하면 하단에 상세 정보가 나타나며, **기본 정보**(서비스 이름, 리소스 유형, 대상 리소스, 최대 생성 개수 등), **허용 프로젝트**, **사용 현황**을 확인할 수 있습니다.
+
+<a id="section-1-3"></a>
 
 ### 사용자 정의 엔드포인트 변경
 
@@ -75,11 +97,15 @@
 
 > [참고] 최대 생성 개수를 줄여도 이미 생성된 서비스 게이트웨이는 유지됩니다. 다만 현재 개수가 최대 생성 개수를 초과하는 동안에는 새 서비스 게이트웨이를 추가로 생성할 수 없습니다.
 
+<a id="section-1-4"></a>
+
 ### 사용자 정의 엔드포인트 삭제
 
 **사용자 정의 엔드포인트** 탭에서 삭제할 엔드포인트를 선택하고 **삭제** 버튼을 클릭합니다.
 
 > [주의] 이 엔드포인트를 사용 중인 서비스 게이트웨이가 하나라도 있으면 삭제할 수 없습니다. 엔드포인트를 삭제하면 등록된 허용 프로젝트도 함께 삭제됩니다.
+
+<a id="section-1-5"></a>
 
 ### 서비스 이름 재발급
 
@@ -90,6 +116,8 @@
 
 > [주의] 재발급하면 기존 서비스 이름은 즉시 폐기되어 더 이상 조회되지 않습니다. 기존 서비스 이름으로 생성한 서비스 게이트웨이는 정상 동작하지만, 새로 서비스 게이트웨이를 생성하려면 재발급된 서비스 이름을 사용해야 합니다.<br>
 > [참고] 서비스 이름 재발급은 엔드포인트를 생성한 프로젝트의 구성원(소유자)만 수행할 수 있습니다.
+
+<a id="section-1-6"></a>
 
 ### 허용 프로젝트 관리
 
@@ -105,17 +133,25 @@
 
 기존 허용 대상은 **설명**만 변경할 수 있으며, 허용 범위와 테넌트 ID는 변경할 수 없습니다. 허용 대상을 삭제하려면 목록에서 대상을 선택하고 **삭제** 버튼을 클릭합니다.
 
+<a id="section-1-7"></a>
+
 ### 사용 현황 확인
 
 엔드포인트 상세 정보의 **사용 현황** 탭에서 이 엔드포인트에 연결 중인 서비스 게이트웨이 목록을 확인할 수 있습니다. (읽기 전용)
 
+<a id="use-a-service-gateway"></a>
+
 ## 서비스 게이트웨이 사용
+
+<a id="check-the-service-gateway-ip"></a>
 
 ### 서비스 게이트웨이 IP확인
 
 1. **Network > Service Gateway**로 이동합니다.
 2. 서비스 게이트웨이 목록에서 **IP 주소**를 확인합니다.<br>
    이 VM Instance에서 이 IP 주소로 접속 시 서비스 게이트웨이가 연결하고 있는 서비스로 연결됩니다.
+
+<a id="connect-to-the-service-gateway"></a>
 
 ### 서비스 게이트웨이 접속
 
@@ -138,9 +174,13 @@
 
             ~# wget https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_8222a22c22244badbf876dcd521f3f98/test-obs/test_file.txt
 
+<a id="example-of-using-object-storage-from-a-service-gateway"></a>
+
 ## 서비스 게이트웨이에서 오브젝트 스토리지 사용 예제
 
 **오브젝트 스토리지**에 관련된 내용은 예제 설명을 위한 수준에서만 기술합니다. 오브젝트 스토리지의 자세한 사용 방법은 **사용자 가이드 > Storage > Oject Storage**를 참고하시기 바랍니다.
+
+<a id="example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway"></a>
 
 ### 서비스 게이트웨이 생성
 
@@ -151,6 +191,8 @@
 2. **IaaS API Identity** 서비스를 선택하여 서비스 게이트웨이를 생성합니다.<br>
    인증 토큰(token) 발급을 위한 서비스 게이트웨이입니다.
 3. 생성된 두 개의 서비스 게이트웨이에서 IP 주소를 확인합니다.
+
+<a id="edit-the-etchosts-file"></a>
 
 ### /etc/hosts 파일 편집
 
@@ -163,6 +205,8 @@
 192.168.1.42	api-identity-infrastructure.nhncloudservice.com
 192.168.1.57	kr1-api-object-storage.nhncloudservice.com
 ```
+
+<a id="obtain-the-authentication-token"></a>
 
 ### 인증 토큰 발급
 
@@ -185,6 +229,8 @@
   아래 응답에서 `access.token.id` 항목의 값이 인증 토큰입니다. `access.token.expires`에 기록된 시간까지 인증 토큰이 유효합니다.
 
             {"access":{"token":{"id":"gAAAAABiVnmCOJVJhh1W2eXGo3aL0eaZxXmd-SMDMIE3zmip2lXy6eH0BlZAlTZBG20dWEm7TF4zi4YIOTKnc6yKh_wqZsyxgMWKkpVNShzE-k6GaSThBP54QeUePSjC2t-R10X6G4xL_Wecl-V-lV-bnOfVo6Ccpz6rv9eLYJnbJw7KrIMSSiY","expires":"2022-04-13T19:19:30Z","tenant":{"id":"2fda9d4b8821111192ff23841198e2e6","name":"tTMgSSSF","groupId":"XXj2zkH7777modGU","description":"","enabled":true,"project_domain":"NORMAL","swift":true},"issued_at":"2022-04-13T07:32:14.000441"},"serviceCatalog":[{"endpoints":[{"region":"KR1","publicURL":"https://api-identity.infrastructure.cloud.toast.com/v2.0"}],"type":"identity","name":"keystone"},{"endpoints":[{"region":"KR2","publicURL":"https://kr2-api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"},{"region":"KR1","publicURL":"https://api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"}],"type":"object-store","name":"swift"}],"user":{"id":"80884888887b45dbaf9b815117130671","username":"5111111c-b111-4b11-b11b-01111f81111f","name":"5211122c-bfc4-4115-b11b-05b52f84
+
+<a id="use-the-object-storage-api"></a>
 
 ### 오브젝트 스토리지 API 사용
 

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=d880ee4f6445 -->
+
+<a id="network-service-gateway-overview"></a>
+
 ## Network > Service Gateway > 개요
 
 **Service Gateway** 서비스를 이용하면 **플로팅 IP**를 쓰지 않고 트래픽이 인터넷을 경유하지 않고도 **VPC** 외부의 NHN Cloud의 **서비스**나 다른 사용자가 게시한 **사용자 정의 엔드포인트**를 이용할 수 있습니다. **서비스 게이트웨이 생성** 시 선택된 연결 대상과 자동으로 할당된 IP는 1:1 연결 관계를 유지하며, **VPC**에서는 **서비스 게이트웨이**의 IP를 이용하여 NHN Cloud의 내부 네트워크를 경유해 대상을 안전하게 이용할 수 있습니다.
+
+<a id="main-features"></a>
 
 ### 주요 기능
 
@@ -13,12 +19,16 @@
 * 서비스 게이트웨이는 현재 한국(판교), 한국(평촌), 한국(광주) 리전에서 제공됩니다. 점차 다른 리전도 지원할 예정입니다.
 * 단, 사용자 정의 엔드포인트는 한국(판교), 한국(평촌) 리전에서만 지원합니다
 
+<a id="provided-services"></a>
+
 ### 제공 서비스
 
 VPC의 VM Instance에서 인터넷을 경유하지 않고 NHN Cloud의 서비스에 접근이 필요한 경우 서비스 게이트웨이에서 제공되는 서비스를 선택하여 서비스 게이트웨이를 생성합니다.
 자세한 사용 방법은 [Service Gateway > 콘솔 사용 가이드](/Network/Service%20Gateway/ko/console-guide/)를 참고하세요.
 
 제공 서비스는 [**서비스 엔드포인트**](/Network/Service%20Gateway/ko/service-endpoint/)를 참고하세요. 제공되는 서비스는 점차 확대될 예정입니다.
+
+<a id="network-service-gateway-overview-1"></a>
 
 ### 사용자 정의 엔드포인트
 

--- a/ko/public-api.md
+++ b/ko/public-api.md
@@ -1,3 +1,7 @@
+<!-- pre-align:aligned sig=0f36aac40dbd -->
+
+<a id="network-service-gateway-api-v2-guide"></a>
+
 ## Network > Service Gateway > API v2 가이드
 
 NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토큰을 사용합니다. IaaS 토큰은 NHN Cloud의 OpenStack 기반 인프라 서비스(IaaS)에서 사용하는 인증 토큰입니다. IaaS 토큰 발급 및 사용에 대한 자세한 내용은 [IaaS 토큰](/nhncloud/ko/public-api/iaas-token)을 참고하세요.
@@ -10,7 +14,11 @@ NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토�
 
 API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니다. 이런 필드는 NHN Cloud 내부 용도로 사용되며 사전 공지 없이 변경될 수 있으므로 사용하지 않습니다.
 
+<a id="service-gateway"></a>
+
 ## 서비스 게이트웨이
+
+<a id="get-a-list-of-service-gateways"></a>
 
 ### 서비스 게이트웨이 목록 보기
 
@@ -18,6 +26,8 @@ API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니
 GET /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
+
+<a id="request"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -34,6 +44,8 @@ X-Auth-Token: {tokenId}
 | fixed_ip| Query | String | - | 조회할 서비스 게이트웨이 IP 주소 |
 | include_gateway_identity| Query | Boolean | - | NAT IP 주소 고정 사용 여부 |
 
+
+<a id="response"></a>
 
 #### 응답
 
@@ -80,12 +92,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="get-a-service-gateway"></a>
+
 ### 서비스 게이트웨이 보기
 
 ```
 GET /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-service-gateway-request"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -94,6 +110,8 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | 토큰 ID |
 | serviceGatewayId | URL | UUID | O | 서비스 게이트웨이 ID |
+
+<a id="get-a-service-gateway-response"></a>
 
 #### 응답
 
@@ -145,12 +163,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="create-a-service-gateway"></a>
+
 ### 서비스 게이트웨이 생성하기
 
 ```
 POST /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
+
+<a id="create-a-service-gateway-request"></a>
 
 #### 요청
 
@@ -185,6 +207,8 @@ X-Auth-Token: {tokenId}
 ```
 
 </details>
+
+<a id="create-a-service-gateway-response"></a>
 
 #### 응답
 
@@ -237,12 +261,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="modify-a-service-gateway"></a>
+
 ### 서비스 게이트웨이 수정하기
 
 ```
 PUT /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="modify-a-service-gateway-request"></a>
 
 #### 요청
 
@@ -268,6 +296,8 @@ X-Auth-Token: {tokenId}
 ```
 
 </details>
+
+<a id="modify-a-service-gateway-response"></a>
 
 #### 응답
 
@@ -320,12 +350,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="delete-a-service-gateway"></a>
+
 ### 서비스 게이트웨이 삭제하기
 
 ```
 DELETE /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="delete-a-service-gateway-request"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -335,6 +369,8 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | serviceGatewayId | URL | UUID | O | 서비스 게이트웨이 ID |
 
+
+<a id="delete-a-service-gateway-response"></a>
 
 #### 응답
 이 API는 응답 본문을 반환하지 않습니다.
@@ -352,7 +388,11 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="service-endpoint"></a>
+
 ## 서비스 엔드포인트
+
+<a id="get-a-list-of-service-endpoints"></a>
 
 ### 서비스 엔드포인트 목록 보기
 
@@ -360,6 +400,8 @@ X-Auth-Token: {tokenId}
 GET /v2.0/gateways/serviceendpoints/
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-list-of-service-endpoints-request"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -373,6 +415,8 @@ X-Auth-Token: {tokenId}
 
 > 서비스 게이트웨이를 사용자 정의 엔드포인트에 연결할 때는 게시자에게 전달받은 `service_name`으로 조회하여 서비스 엔드포인트 ID를 획득합니다. 보안을 위해 `service_name` 값은 응답에 포함되지 않으며, 허용 프로젝트에 포함되지 않은 경우 빈 목록이 반환됩니다.
 
+
+<a id="get-a-list-of-service-endpoints-response"></a>
 
 #### 응답
 
@@ -403,12 +447,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="get-a-service-endpoint"></a>
+
 ### 서비스 엔드포인트 보기
 
 ```
 GET /v2.0/gateways/serviceendpoints/{seerviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="get-a-service-endpoint-request"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -417,6 +465,8 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | 토큰 ID |
 | serviceEndpointId | URL | UUID | O | 서비스 엔드포인트 ID |
+
+<a id="get-a-service-endpoint-response"></a>
 
 #### 응답
 
@@ -445,9 +495,13 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="section-1"></a>
+
 ## 사용자 정의 엔드포인트
 
 사용자가 자신의 리소스(로드 밸런서)를 엔드포인트로 게시하여 다른 프로젝트와 공유하는 기능입니다. 게시자(소유자)가 생성/관리하며, 생성 시 공유용 서비스 이름(`service_name`)이 발급됩니다.
+
+<a id="section-1-1"></a>
 
 ### 사용자 정의 엔드포인트 목록 보기
 
@@ -455,6 +509,8 @@ X-Auth-Token: {tokenId}
 GET /v2.0/gateways/myserviceendpoints
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-1-1-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -465,6 +521,8 @@ X-Auth-Token: {tokenId}
 | id | Query | UUID | - | 조회할 사용자 정의 엔드포인트 ID |
 | endpoint_type | Query | String | - | 조회할 엔드포인트 유형(예: `lb.type1`) |
 | port_id | Query | UUID | - | 조회할 대상 리소스(로드 밸런서) 포트 ID |
+
+<a id="section-1-1-2"></a>
 
 #### 응답
 
@@ -508,12 +566,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="section-1-2"></a>
+
 ### 사용자 정의 엔드포인트 보기
 
 ```
 GET /v2.0/gateways/myserviceendpoints/{serviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-1-2-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -522,6 +584,8 @@ X-Auth-Token: {tokenId}
 |---|---|---|---|---|
 | tokenId | Header | String | O | 토큰 ID |
 | serviceEndpointId | URL | UUID | O | 사용자 정의 엔드포인트 ID |
+
+<a id="section-1-2-2"></a>
 
 #### 응답
 
@@ -563,12 +627,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="section-1-3"></a>
+
 ### 사용자 정의 엔드포인트 생성하기
 
 ```
 POST /v2.0/gateways/myserviceendpoints
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-1-3-1"></a>
 
 #### 요청
 
@@ -600,16 +668,22 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="section-1-3-2"></a>
+
 #### 응답
 응답 본문은 [사용자 정의 엔드포인트 보기](#사용자-정의-엔드포인트-보기)와 동일하며, 자동 발급된 `service_name`이 포함됩니다.
 
 ---
+<a id="section-1-4"></a>
+
 ### 사용자 정의 엔드포인트 수정하기
 
 ```
 PUT /v2.0/gateways/myserviceendpoints/{serviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-1-4-1"></a>
 
 #### 요청
 
@@ -640,16 +714,22 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="section-1-4-2"></a>
+
 #### 응답
 응답 본문은 [사용자 정의 엔드포인트 보기](#사용자-정의-엔드포인트-보기)와 동일합니다.
 
 ---
+<a id="section-1-5"></a>
+
 ### 사용자 정의 엔드포인트 삭제하기
 
 ```
 DELETE /v2.0/gateways/myserviceendpoints/{serviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-1-5-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -661,16 +741,22 @@ X-Auth-Token: {tokenId}
 
 > 이 엔드포인트를 사용 중인 서비스 게이트웨이가 있으면 삭제할 수 없습니다. 삭제 시 등록된 허용 프로젝트도 함께 삭제됩니다.
 
+<a id="section-1-5-2"></a>
+
 #### 응답
 이 API는 응답 본문을 반환하지 않습니다.
 
 ---
+<a id="section-1-6"></a>
+
 ### 서비스 이름 재발급하기
 
 ```
 PUT /v2.0/gateways/serviceendpoints/{serviceEndpointId}/generate_service_name
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-1-6-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -681,6 +767,8 @@ X-Auth-Token: {tokenId}
 | serviceEndpointId | URL | UUID | O | 사용자 정의 엔드포인트 ID |
 
 > 엔드포인트를 생성한 프로젝트의 구성원(소유자)만 수행할 수 있습니다. 재발급 시 기존 `service_name`은 즉시 폐기되어 더 이상 조회되지 않습니다. 기존 `service_name`으로 생성한 서비스 게이트웨이는 정상 동작하지만, 신규 생성 시에는 재발급된 `service_name`을 사용해야 합니다.
+
+<a id="section-1-6-2"></a>
 
 #### 응답
 
@@ -699,9 +787,13 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="section-2"></a>
+
 ## 허용 프로젝트
 
 사용자 정의 엔드포인트에 연결(서비스 게이트웨이 생성)을 허용할 대상(테넌트)을 관리하는 목록(white list)입니다. 순수 허용 목록(권한)이며 생성 개수 제한은 다루지 않습니다(개수 제한은 엔드포인트의 `max_count`에서 관리).
+
+<a id="section-2-1"></a>
 
 ### 허용 프로젝트 목록 보기
 
@@ -709,6 +801,8 @@ X-Auth-Token: {tokenId}
 GET /v2.0/gateways/serviceendpointallowprojects
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-2-1-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -718,6 +812,8 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | service_endpoint_id | Query | UUID | - | 조회할 사용자 정의 엔드포인트 ID |
 | target_tenant_id | Query | String | - | 조회할 허용 대상 테넌트 ID |
+
+<a id="section-2-1-2"></a>
 
 #### 응답
 
@@ -749,12 +845,16 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
+<a id="section-2-2"></a>
+
 ### 허용 프로젝트 보기
 
 ```
 GET /v2.0/gateways/serviceendpointallowprojects/{allowProjectId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-2-2-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -764,16 +864,22 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | allowProjectId | URL | UUID | O | 허용 프로젝트 ID |
 
+<a id="section-2-2-2"></a>
+
 #### 응답
 응답 본문은 [허용 프로젝트 목록 보기](#허용-프로젝트-목록-보기)의 단일 객체(`serviceendpointallowproject`)와 동일합니다.
 
 ---
+<a id="section-2-3"></a>
+
 ### 허용 프로젝트 생성하기
 
 ```
 POST /v2.0/gateways/serviceendpointallowprojects
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-2-3-1"></a>
 
 #### 요청
 
@@ -803,16 +909,22 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="section-2-3-2"></a>
+
 #### 응답
 응답 본문은 [허용 프로젝트 목록 보기](#허용-프로젝트-목록-보기)의 단일 객체(`serviceendpointallowproject`)와 동일합니다.
 
 ---
+<a id="section-2-4"></a>
+
 ### 허용 프로젝트 수정하기
 
 ```
 PUT /v2.0/gateways/serviceendpointallowprojects/{allowProjectId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-2-4-1"></a>
 
 #### 요청
 
@@ -839,16 +951,22 @@ X-Auth-Token: {tokenId}
 
 </details>
 
+<a id="section-2-4-2"></a>
+
 #### 응답
 응답 본문은 [허용 프로젝트 목록 보기](#허용-프로젝트-목록-보기)의 단일 객체(`serviceendpointallowproject`)와 동일합니다.
 
 ---
+<a id="section-2-5"></a>
+
 ### 허용 프로젝트 삭제하기
 
 ```
 DELETE /v2.0/gateways/serviceendpointallowprojects/{allowProjectId}
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-2-5-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -858,13 +976,19 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | allowProjectId | URL | UUID | O | 허용 프로젝트 ID |
 
+<a id="section-2-5-2"></a>
+
 #### 응답
 이 API는 응답 본문을 반환하지 않습니다.
 
 ---
+<a id="section-3"></a>
+
 ## 사용 현황
 
 사용자 정의 엔드포인트를 사용 중인(연결한) 소비자 측 서비스 게이트웨이 목록을 조회합니다.
+
+<a id="section-3-1"></a>
 
 ### 사용 현황 목록 보기
 
@@ -872,6 +996,8 @@ X-Auth-Token: {tokenId}
 GET /v2.0/gateways/serviceendpointusages
 X-Auth-Token: {tokenId}
 ```
+
+<a id="section-3-1-1"></a>
 
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
@@ -890,6 +1016,8 @@ X-Auth-Token: {tokenId}
 
 > 결과는 기본적으로 서비스 게이트웨이 ID(`id`) 오름차순으로 정렬됩니다. 생성 시각순으로 조회하려면 `sort_key=create_time&sort_dir=desc`와 같이 명시해야 합니다. `sort_key`에는 응답 필드(`id`, `name`, `fixed_ip`, `status`, `tenant_id`, `network_id`, `subnet_id`, `service_endpoint_id`, `create_time`)를 사용할 수 있습니다.
 > `limit`을 지정하면 응답에 다음/이전 페이지 링크(`serviceendpointusages_links`)가 포함됩니다. 다음 페이지는 링크의 URL을 그대로 호출하거나, 현재 페이지 마지막 항목의 `id`를 `marker`로 지정해 조회합니다. 페이지를 순회하는 동안에는 동일한 필터/정렬 조건을 유지해야 합니다.
+
+<a id="section-3-1-2"></a>
 
 #### 응답
 

--- a/ko/service-endpoint.md
+++ b/ko/service-endpoint.md
@@ -1,6 +1,12 @@
+<!-- pre-align:aligned sig=1d1c35e9431e -->
+
+<a id="network-service-gateway-service-endpoint"></a>
+
 ## Network > Service Gateway > 서비스 엔드포인트
 
 서비스 게이트웨이를 이용하여 NHN Cloud 내부 네트워크로 통신할 수 있는 서비스 목록 및 각 서비스별 엔드포인트입니다.
+
+<a id="region-code"></a>
 
 ### 리전 코드
 
@@ -12,6 +18,8 @@
 | 한국(평촌) | kr2 |
 | 한국(광주) | kr3 |
 | 일본(도쿄) | jp1 |
+
+<a id="service-gateway-integration-services"></a>
 
 ### 서비스 게이트웨이 연동 서비스
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `claude-code (CLI)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 4 doc(s) scanned · 12 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/39/ |
| Generated | 2026-07-08T05:32:12 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FService-Gateway%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FService-Gateway%2Fpull%2F75&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FService-Gateway%2Fpull%2F75&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/console-guide.md` | 0 | 8 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/console-guide.md` | 0 | 8 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/overview.md` | 0 | 1 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/overview.md` | 0 | 1 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/public-api.md` | 0 | 39 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/public-api.md` | 0 | 39 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ko/service-endpoint.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `en/service-endpoint.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |
| `ja/service-endpoint.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Service-Gateway`