### PR TITLE
chore(pre-align): align heading structure (4 docs) with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,10 +1,15 @@
-## Network > Service Gateway > Console User Guide
+<!-- pre-align:aligned sig=618efc96173d -->
+
+<a id="network-service-gateway-console-user-guide"></a>
+## Network > Service Gateway > Console User Guide { #network-service-gateway-console-user-guide }
 
 This guides describes how to use the **Service Gateway** service from the console.
 
-## Service Gateway
+<a id="service-gateway"></a>
+## Service Gateway { #service-gateway }
 
-### Create a Service Gateway
+<a id="create-a-service-gateway"></a>
+### Create a Service Gateway { #create-a-service-gateway }
 
 To create a service gateway, use the following steps:
 
@@ -23,30 +28,36 @@ To create a service gateway, use the following steps:
     * Selection is only possible at creation time, and changes are not supported.
     > [Note] It is only enabled on services that allow selection.
 
-### View a Service Gateway
+<a id="view-a-service-gateway"></a>
+### View a Service Gateway { #view-a-service-gateway }
 
 You can check the created service gateway on the **Network > Service Gateway** page. If you select a service gateway, the service gateway information appears at the bottom.
 
-### Modify a Service Gateway
+<a id="modify-a-service-gateway"></a>
+### Modify a Service Gateway { #modify-a-service-gateway }
 
 A service gateway can be modified as follows. You can only change the **Name** and **Description**.
 
 1. Go to **Network > Service Gateway**.
 2. Click **Change Service Gateway** and change items on the change screen.
 
-### Delete a Service Gateway
+<a id="delete-a-service-gateway"></a>
+### Delete a Service Gateway { #delete-a-service-gateway }
 
 To delete a service gateway, select the service gateway you want to delete in the **Network > Service Gateway** page and click the **Delete Service Gateway** button.
 
-## Use a Service Gateway
+<a id="use-a-service-gateway"></a>
+## Use a Service Gateway { #use-a-service-gateway }
 
-### Check the Service Gateway IP
+<a id="check-the-service-gateway-ip"></a>
+### Check the Service Gateway IP { #check-the-service-gateway-ip }
 
 1. Go to **Network > Service Gateway**.
 2. Check the **IP address** in the list of service gateways.<br>
    When the VM Instance accesses this IP address, it is connected to the service that the service gateway is connected to.
 
-### Connect to the Service Gateway
+<a id="connect-to-the-service-gateway"></a>
+### Connect to the Service Gateway { #connect-to-the-service-gateway }
 
 For example, if the IP address of the created service gateway is `192.168.1.42`, the service can be accessed in the following ways.
 
@@ -67,11 +78,13 @@ For example, if the IP address of the created service gateway is `192.168.1.42`,
 
             ~# wget https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_8222a22c22244badbf876dcd521f3f98/test-obs/test_file.txt
 
-## Example of Using Object Storage from a Service Gateway
+<a id="example-of-using-object-storage-from-a-service-gateway"></a>
+## Example of Using Object Storage from a Service Gateway { #example-of-using-object-storage-from-a-service-gateway }
 
 Content related to **object storage** are described only at the level required for explaining the example. For details on how to use object storage, refer to **User Guide > Storage > Object Storage**.
 
-### Create a Service Gateway
+<a id="example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway"></a>
+### Create a Service Gateway { #example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway }
 
 To use the **Object Storage API**, you must obtain an **authentication token**. To use object storage in a VPC in an isolated environment where internet is not available, you must obtain an authentication token also using the service gateway, and create the service gateway according to the following steps.
 
@@ -81,7 +94,8 @@ To use the **Object Storage API**, you must obtain an **authentication token**. 
    A service gateway for obtaining the authentication token.
 3. Check the IP addresses on the two service gateways that have been created.
 
-### Edit the /etc/hosts File
+<a id="edit-the-etchosts-file"></a>
+### Edit the /etc/hosts File { #edit-the-etchosts-file }
 
 For example, if the IP address of the service gateway created by selecting **Object Storage** is 192.168.1.42 and 192.168.1.57 is assigned as the IP address of the service gateway created by selecting **IaaS API Identity**, add the IP addresses and URLs to the `/etc/hosts` file of the VM Instance, as shown below.
 
@@ -93,7 +107,8 @@ For example, if the IP address of the service gateway created by selecting **Obj
 192.168.1.57	kr1-api-object-storage.nhncloudservice.com
 ```
 
-### Obtain the Authentication Token
+<a id="obtain-the-authentication-token"></a>
+### Obtain the Authentication Token { #obtain-the-authentication-token }
 
 **Set the API password** for object storage and get an authentication token.
 
@@ -115,7 +130,8 @@ For example, if the IP address of the service gateway created by selecting **Obj
 
             {"access":{"token":{"id":"gAAAAABiVnmCOJVJhh1W2eXGo3aL0eaZxXmd-SMDMIE3zmip2lXy6eH0BlZAlTZBG20dWEm7TF4zi4YIOTKnc6yKh_wqZsyxgMWKkpVNShzE-k6GaSThBP54QeUePSjC2t-R10X6G4xL_Wecl-V-lV-bnOfVo6Ccpz6rv9eLYJnbJw7KrIMSSiY","expires":"2022-04-13T19:19:30Z","tenant":{"id":"2fda9d4b8821111192ff23841198e2e6","name":"tTMgSSSF","groupId":"XXj2zkH7777modGU","description":"","enabled":true,"project_domain":"NORMAL","swift":true},"issued_at":"2022-04-13T07:32:14.000441"},"serviceCatalog":[{"endpoints":[{"region":"KR1","publicURL":"https://api-identity.infrastructure.cloud.toast.com/v2.0"}],"type":"identity","name":"keystone"},{"endpoints":[{"region":"KR2","publicURL":"https://kr2-api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"},{"region":"KR1","publicURL":"https://api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"}],"type":"object-store","name":"swift"}],"user":{"id":"80884888887b45dbaf9b815117130671","username":"5111111c-b111-4b11-b11b-01111f81111f","name":"5211122c-bfc4-4115-b11b-05b52f84
 
-### Use the Object Storage API
+<a id="use-the-object-storage-api"></a>
+### Use the Object Storage API { #use-the-object-storage-api }
 
 When you have finished obtaining the authentication token, you can use the Object Storage API. Assuming that a container named example is created in the object storage and test_file.txt is uploaded to the container, you can query the file in the container by using the API as shown below.
 

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,8 +1,12 @@
-## Network > Service Gateway > Overview
+<!-- pre-align:aligned sig=321428a4bf12 -->
+
+<a id="network-service-gateway-overview"></a>
+## Network > Service Gateway > Overview { #network-service-gateway-overview }
 
 The **Service Gateway** service allows you to use the **services** of NHN Cloud outside the **VPC** without using a **floating IP** and having the traffic going through the internet. The **service** selected when **creating the service gateway** and the automatically assigned IP maintain a one-to-one relationship. In the **VPC**, you can use the target **service** safely through the NHN Cloud's internal network using the **service gateway**'s IP address.
 
-### Main Features
+<a id="main-features"></a>
+### Main Features { #main-features }
 
 * You can connect to the services of NHN Cloud provided by the service gateway from your VPC without going through the internet.
 * You can use only the services provided in the service list when creating a service gateway.
@@ -10,7 +14,8 @@ The **Service Gateway** service allows you to use the **services** of NHN Cloud 
 * When the VM Instance in the VPC communicates with the IP address of the service gateway, it communicates with the service associated with the service gateway.
 * This service is currently only available in the Korea (Pangyo) and Korea (Pyeongchon) regions, and will be supported by other regions gradually.
 
-### Provided Services
+<a id="provided-services"></a>
+### Provided Services { #provided-services }
 
 If you need to access NHN Cloud's services from a VM Instance in the VPC without going through the internet, create a service gateway by selecting a service provided by the service gateway.
 For details on how to use each service, refer to the [Service Gateway > Console User Guide](/Network/Service%20Gateway/en/console-guide/). 

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -1,5 +1,7 @@
+<!-- pre-align:aligned sig=0fdf7e57a581 -->
 
-## Network > Service Gateway > API v2 Guide
+<a id="network-service-gateway-api-v2-guide"></a>
+## Network > Service Gateway > API v2 Guide { #network-service-gateway-api-v2-guide }
 
 NHN Cloud Network services use IaaS tokens for authentication and authorization when making API calls. The IaaS token is an authentication token used for NHN Cloud's OpenStack-based infrastructure services (IaaS). For more information on issuing and using IaaS tokens, please refer to the [IaaS Token](/nhncloud/en/public-api/iaas-token).
 
@@ -11,15 +13,18 @@ For Service Gateway APIs, the `network` type endpoint is used. For more details,
 
 In each API response, you may find fields that are not specified within this guide. Those fields are for NHN Cloud internal usage, so refrain from using them because they may be changed without prior notice.
 
-## Service Gateway
+<a id="service-gateway"></a>
+## Service Gateway { #service-gateway }
 
-### Get a List of Service Gateways
+<a id="get-a-list-of-service-gateways"></a>
+### Get a List of Service Gateways { #get-a-list-of-service-gateways }
 
 ```
 GET /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-list-of-service-gateways-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -36,6 +41,7 @@ This API does not require a request body.
 include_gateway_identity| Query | Boolean | - | Whether to use fixed NAT IP address |
 
 
+<a id="get-a-list-of-service-gateways-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -78,13 +84,15 @@ include_gateway_identity| Query | Boolean | - | Whether to use fixed NAT IP addr
 </details>
 
 ---
-### Get a Service Gateway
+<a id="get-a-service-gateway"></a>
+### Get a Service Gateway { #get-a-service-gateway }
 
 ```
 GET /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-service-gateway-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -93,6 +101,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | serviceGatewayId | URL | UUID | O | The ID of the service gateway |
 
+<a id="get-a-service-gateway-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -140,13 +149,15 @@ This API does not require a request body.
 </details>
 
 ---
-### Create a Service Gateway
+<a id="create-a-service-gateway"></a>
+### Create a Service Gateway { #create-a-service-gateway }
 
 ```
 POST /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-service-gateway-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -180,6 +191,7 @@ X-Auth-Token: {tokenId}
 ```
 </details>
 
+<a id="create-a-service-gateway-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -228,13 +240,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### Modify a Service Gateway
+<a id="modify-a-service-gateway"></a>
+### Modify a Service Gateway { #modify-a-service-gateway }
 
 ```
 PUT /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modify-a-service-gateway-request"></a>
 #### Request
 
 | Name | Type | Format | Required | Description |
@@ -257,6 +271,7 @@ X-Auth-Token: {tokenId}
 ```
 </details>
 
+<a id="modify-a-service-gateway-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -305,13 +320,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### Delete a Service Gateway
+<a id="delete-a-service-gateway"></a>
+### Delete a Service Gateway { #delete-a-service-gateway }
 
 ```
 DELETE /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-service-gateway-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -321,6 +338,7 @@ This API does not require a request body.
 | serviceGatewayId | URL | UUID | O | The ID of the service gateway |
 
 
+<a id="delete-a-service-gateway-response"></a>
 #### Response
 Stops the specified node group.
 
@@ -333,15 +351,18 @@ Stops the specified node group.
 
 
 
-## Service Endpoint
+<a id="service-endpoint"></a>
+## Service Endpoint { #service-endpoint }
 
-### Get a List of Service Endpoints
+<a id="get-a-list-of-service-endpoints"></a>
+### Get a List of Service Endpoints { #get-a-list-of-service-endpoints }
 
 ```
 GET /v2.0/gateways/serviceendpoints/
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-list-of-service-endpoints-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -353,6 +374,7 @@ This API does not require a request body.
 
 
 
+<a id="get-a-list-of-service-endpoints-response"></a>
 #### Response
 
 | Name | Type | Format | Description |
@@ -381,13 +403,15 @@ This API does not require a request body.
 </details>
 
 ---
-### Get a Service Endpoint
+<a id="get-a-service-endpoint"></a>
+### Get a Service Endpoint { #get-a-service-endpoint }
 
 ```
 GET /v2.0/gateways/serviceendpoints/{seerviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-service-endpoint-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -396,6 +420,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID |
 | serviceEndpointId | URL | UUID | O | Service endpoint ID |
 
+<a id="get-a-service-endpoint-response"></a>
 #### Response
 
 | Name | Type | Format | Description |

--- a/en/service-endpoint.md
+++ b/en/service-endpoint.md
@@ -1,8 +1,12 @@
-## Network > Service Gateway > Service Endpoint
+<!-- pre-align:aligned sig=1d1c35e9431e -->
+
+<a id="network-service-gateway-service-endpoint"></a>
+## Network > Service Gateway > Service Endpoint { #network-service-gateway-service-endpoint }
 
 A list of services that can communicate with the NHN Cloud internal network using Service Gateway and the endpoints for each service.
 
-### Region Code
+<a id="region-code"></a>
+### Region Code { #region-code }
 
 * Region services have different endpoint addresses for each region, so you must fill in the region code below `{region code}`.
 
@@ -13,7 +17,8 @@ A list of services that can communicate with the NHN Cloud internal network usin
 | Korea (Gwangju) | kr3 |
 | Japan (Tokyo) | jp1 |
 
-### Service Gateway Integration Services
+<a id="service-gateway-integration-services"></a>
+### Service Gateway Integration Services { #service-gateway-integration-services }
 
 * By creating a service gateway with the services below, you can access the internal network of NHN Cloud without going through the Internet.
     * To create a service gateway, see the [Service Gateway > Console User Guide](/Network/Service%20Gateway/en/console-guide/).

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,10 +1,15 @@
-## Network > Service Gateway > コンソール使用ガイド
+<!-- pre-align:aligned sig=618efc96173d -->
+
+<a id="network-service-gateway-console-user-guide"></a>
+## Network > Service Gateway > コンソール使用ガイド { #network-service-gateway-console-user-guide }
 
 コンソールで**Service Gateway**サービスを使用する方法を説明します。
 
-## サービスゲートウェイ
+<a id="service-gateway"></a>
+## サービスゲートウェイ { #service-gateway }
 
-### サービスゲートウェイの作成
+<a id="create-a-service-gateway"></a>
+### サービスゲートウェイの作成 { #create-a-service-gateway }
 
 サービスゲートウェイを作成する方法は次のとおりです。
 
@@ -23,30 +28,36 @@
     * 作成時にのみ選択可能で、変更はサポートしていません。
     > [参考] 選択が可能なサービスでのみ有効になります。
 
-### サービスゲートウェイの照会
+<a id="view-a-service-gateway"></a>
+### サービスゲートウェイの照会 { #view-a-service-gateway }
 
 作成したサービスゲートウェイは**Network > Service Gateway**画面で確認できます。サービスゲートウェイを選択すると、下部にサービスゲートウェイ情報が表示されます。
 
-### サービスゲートウェイの変更
+<a id="modify-a-service-gateway"></a>
+### サービスゲートウェイの変更 { #modify-a-service-gateway }
 
 サービスゲートウェイを変更する方法は次のとおりです。**名前**、**説明**のみ変更できます。
 
 1. **Network > Service Gateway**に移動します。
 2. **サービスゲートウェイ変更**ボタンをクリックし、変更画面で項目を変更します。
 
-### サービスゲートウェイの削除
+<a id="delete-a-service-gateway"></a>
+### サービスゲートウェイの削除 { #delete-a-service-gateway }
 
 サービスゲートウェイを削除するには**Network > Service Gateway**画面で削除するサービスゲートウェイを選択し、**サービスゲートウェイ削除**ボタンをクリックします。
 
-## サービスゲートウェイの使用
+<a id="use-a-service-gateway"></a>
+## サービスゲートウェイの使用 { #use-a-service-gateway }
 
-### サービスゲートウェイIPの確認
+<a id="check-the-service-gateway-ip"></a>
+### サービスゲートウェイIPの確認 { #check-the-service-gateway-ip }
 
 1. **Network > Service Gateway**に移動します。
 2. サービスゲートウェイリストで**IPアドレス**を確認します。<br>
   このVM InstanceからこのIPアドレスに接続すると、サービスゲートウェイが接続しているサービスに接続されます。
 
-### サービスゲートウェイ接続
+<a id="connect-to-the-service-gateway"></a>
+### サービスゲートウェイ接続 { #connect-to-the-service-gateway }
 
 作成されたサービスゲートウェイのIPアドレスが`192.168.1.42`である場合、次のような方法でサービスにアクセスできます。
 
@@ -67,11 +78,13 @@
 
             ~# wget https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_8222a22c22244badbf876dcd521f3f98/test-obs/test_file.txt
 
-## サービスゲートウェイでオブジェクトストレージを使用する例
+<a id="example-of-using-object-storage-from-a-service-gateway"></a>
+## サービスゲートウェイでオブジェクトストレージを使用する例 { #example-of-using-object-storage-from-a-service-gateway }
 
 **オブジェクトストレージ**に関連する内容は、例を説明するための水準でのみ記述します。オブジェクトストレージの詳細については**ユーザーガイド > Storage > Oject Storage**を参照してください。
 
-### サービスゲートウェイの作成
+<a id="example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway"></a>
+### サービスゲートウェイの作成 { #example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway }
 
 **オブジェクトストレージAPI**を使用するには**認証トークン**を発行する必要があります。インターネットを使用できない隔離された環境のVPCからObject Storageを使用するには認証トークンもサービスゲートウェイを利用して発行する必要があり、次の手順に従ってサービスゲートウェイを作成する必要があります。
 
@@ -81,7 +94,8 @@
  認証トークン(token)を発行するためのサービスゲートウェイです。
 3. 作成された2つのサービスゲートウェイでIPアドレスを確認します。
 
-### /etc/hostsファイルの編集
+<a id="edit-the-etchosts-file"></a>
+### /etc/hostsファイルの編集 { #edit-the-etchosts-file }
 
 **Object Storage**を選択して作成したサービスゲートウェイのIPアドレスが192.168.1.42で、**IaaS API Identity**を選択して作成したサービスゲートウェイのIPアドレスに192.168.1.57が割り当てられた場合、VM Instanceの`/etc/hosts`ファイルに以下のようにIPアドレスとURLを追加します。
 
@@ -93,7 +107,8 @@
 192.168.1.57	kr1-api-object-storage.nhncloudservice.com
 ```
 
-### 認証トークンの発行
+<a id="obtain-the-authentication-token"></a>
+### 認証トークンの発行 { #obtain-the-authentication-token }
 
 オブジェクトストレージの**APIパスワード設定**を行い、認証トークンを発行します。
 
@@ -113,7 +128,8 @@
 
             {"access":{"token":{"id":"gAAAAABiVnmCOJVJhh1W2eXGo3aL0eaZxXmd-SMDMIE3zmip2lXy6eH0BlZAlTZBG20dWEm7TF4zi4YIOTKnc6yKh_wqZsyxgMWKkpVNShzE-k6GaSThBP54QeUePSjC2t-R10X6G4xL_Wecl-V-lV-bnOfVo6Ccpz6rv9eLYJnbJw7KrIMSSiY","expires":"2022-04-13T19:19:30Z","tenant":{"id":"2fda9d4b8821111192ff23841198e2e6","name":"tTMgSSSF","groupId":"XXj2zkH7777modGU","description":"","enabled":true,"project_domain":"NORMAL","swift":true},"issued_at":"2022-04-13T07:32:14.000441"},"serviceCatalog":[{"endpoints":[{"region":"KR1","publicURL":"https://api-identity.infrastructure.cloud.toast.com/v2.0"}],"type":"identity","name":"keystone"},{"endpoints":[{"region":"KR2","publicURL":"https://kr2-api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"},{"region":"KR1","publicURL":"https://api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"}],"type":"object-store","name":"swift"}],"user":{"id":"80884888887b45dbaf9b815117130671","username":"5111111c-b111-4b11-b11b-01111f81111f","name":"5211122c-bfc4-4115-b11b-05b52f84
 
-### オブジェクトストレージAPIの使用
+<a id="use-the-object-storage-api"></a>
+### オブジェクトストレージAPIの使用 { #use-the-object-storage-api }
 
 認証トークンの発行が完了したらオブジェクトストレージAPIを使用できます。オブジェクトストレージにexampleというコンテナを作成し、test_file.txtを入れたと仮定した場合、以下のようなAPI使用方法でコンテナにあるファイルを照会できます。
 

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,8 +1,12 @@
-## Network > Service Gateway > 概要
+<!-- pre-align:aligned sig=321428a4bf12 -->
+
+<a id="network-service-gateway-overview"></a>
+## Network > Service Gateway > 概要 { #network-service-gateway-overview }
 
 **Service Gateway**サービスを利用すると**Floating IP**を使用せず、トラフィックがインターネットを経由しなくても**VPC**外部のNHN Cloudの**サービス**を利用できます。**サービスゲートウェイ作成**時に選択された**サービス**と自動的に割り当てられたIPは1:1接続関係を維持し、**VPC**では**サービスゲートウェイ**のIPを利用してNHN Cloudの内部ネットワークを経由して対象**サービス**を安全に利用できます。
 
-### 主な機能
+<a id="main-features"></a>
+### 主な機能 { #main-features }
 
 * VPCからインターネットを経由せずにサービスゲートウェイで提供するNHN Cloudのサービスに接続できます。
 * サービスゲートウェイ作成時にサービスリストに提供されるサービスのみ利用可能です。
@@ -10,7 +14,8 @@
 * VPCのVM InstanceからサービスゲートウェイのIPアドレスに通信すると、サービスゲートウェイに接続されたサービスと通信されます。
 * 現在は韓国(パンギョ)、韓国(ピョンチョン)リージョンにのみ提供されます。今後、他のリージョンもサポートする予定です。
 
-### 提供サービス
+<a id="provided-services"></a>
+### 提供サービス { #provided-services }
 
 VPCのVM Instanceからインターネットを経由せずにNHN Cloudのサービスにアクセスする必要がある場合は、サービスゲートウェイで提供されるサービスを選択してサービスゲートウェイを作成します。
 詳細な使い方は[Service Gateway > コンソール使用ガイド](/Network/Service%20Gateway/ja/console-guide/)を参照してください。

--- a/ja/public-api.md
+++ b/ja/public-api.md
@@ -1,5 +1,7 @@
+<!-- pre-align:aligned sig=0fdf7e57a581 -->
 
-## Network > Service Gateway > API v2ガイド
+<a id="network-service-gateway-api-v2-guide"></a>
+## Network > Service Gateway > API v2ガイド { #network-service-gateway-api-v2-guide }
 
 NHN Cloud Networkサービスは、API呼び出し時の認証/認可のためにIaaSトークンを使用します。IaaSトークンは、NHN CloudのOpenStackベースのインフラサービス(IaaS)で使用する認証トークンです。IaaSトークンの発行及び使用に関する詳細は、[IaaSトークン](/nhncloud/ja/public-api/iaas-token)を参照してください。
 
@@ -11,15 +13,18 @@ NHN Cloud Networkサービスは、API呼び出し時の認証/認可のため�
 
 APIレスポンスにガイドに記載されていないフィールドが表示される場合があります。このようなフィールドは、NHN Cloudの内部用途に使用され、事前告知なしに変更される可能性があるため、使用しないでください。
 
-## サービスゲートウェイ
+<a id="service-gateway"></a>
+## サービスゲートウェイ { #service-gateway }
 
-### サービスゲートウェイリスト表示
+<a id="get-a-list-of-service-gateways"></a>
+### サービスゲートウェイリスト表示 { #get-a-list-of-service-gateways }
 
 ```
 GET /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-list-of-service-gateways-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -36,6 +41,7 @@ X-Auth-Token: {tokenId}
 | include_gateway_identity| Query | Boolean | - | NAT IPアドレス固定の使用有無 |
 
 
+<a id="get-a-list-of-service-gateways-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -78,13 +84,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### サービスゲートウェイ表示
+<a id="get-a-service-gateway"></a>
+### サービスゲートウェイ表示 { #get-a-service-gateway }
 
 ```
 GET /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-service-gateway-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -93,6 +101,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | serviceGatewayId | URL | UUID | O | サービスゲートウェイID |
 
+<a id="get-a-service-gateway-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -140,13 +149,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### サービスゲートウェイを作成する
+<a id="create-a-service-gateway"></a>
+### サービスゲートウェイを作成する { #create-a-service-gateway }
 
 ```
 POST /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-service-gateway-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -180,6 +191,7 @@ X-Auth-Token: {tokenId}
 ```
 </details>
 
+<a id="create-a-service-gateway-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -228,13 +240,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### サービスゲートウェイを修正する
+<a id="modify-a-service-gateway"></a>
+### サービスゲートウェイを修正する { #modify-a-service-gateway }
 
 ```
 PUT /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modify-a-service-gateway-request"></a>
 #### リクエスト
 
 | 名前 | 種類 | 形式 | 必須 | 説明 |
@@ -257,6 +271,7 @@ X-Auth-Token: {tokenId}
 ```
 </details>
 
+<a id="modify-a-service-gateway-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -305,13 +320,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### サービスゲートウェイを削除する
+<a id="delete-a-service-gateway"></a>
+### サービスゲートウェイを削除する { #delete-a-service-gateway }
 
 ```
 DELETE /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-service-gateway-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -321,6 +338,7 @@ X-Auth-Token: {tokenId}
 | serviceGatewayId | URL | UUID | O | サービスゲートウェイID |
 
 
+<a id="delete-a-service-gateway-response"></a>
 #### レスポンス
 このAPIはレスポンス本文を返しません。
 
@@ -333,15 +351,18 @@ X-Auth-Token: {tokenId}
 
 
 
-## サービスエンドポイント
+<a id="service-endpoint"></a>
+## サービスエンドポイント { #service-endpoint }
 
-### サービスエンドポイントリスト表示
+<a id="get-a-list-of-service-endpoints"></a>
+### サービスエンドポイントリスト表示 { #get-a-list-of-service-endpoints }
 
 ```
 GET /v2.0/gateways/serviceendpoints/
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-list-of-service-endpoints-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -353,6 +374,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="get-a-list-of-service-endpoints-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |
@@ -381,13 +403,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### サービスエンドポイント表示
+<a id="get-a-service-endpoint"></a>
+### サービスエンドポイント表示 { #get-a-service-endpoint }
 
 ```
 GET /v2.0/gateways/serviceendpoints/{seerviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-service-endpoint-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -396,6 +420,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID |
 | serviceEndpointId | URL | UUID | O | サービスエンドポイントID |
 
+<a id="get-a-service-endpoint-response"></a>
 #### レスポンス
 
 | 名前 | 種類 | 形式 | 説明 |

--- a/ja/service-endpoint.md
+++ b/ja/service-endpoint.md
@@ -1,8 +1,12 @@
-## Network > Service Gateway > 連動サービスエンドポイント
+<!-- pre-align:aligned sig=1d1c35e9431e -->
+
+<a id="network-service-gateway-service-endpoint"></a>
+## Network > Service Gateway > 連動サービスエンドポイント { #network-service-gateway-service-endpoint }
 
 サービスゲートウェイを利用してNHN Cloudの内部ネットワークと通信できるサービスリスト及び各サービスのエンドポイントです。
 
-### リージョンコード
+<a id="region-code"></a>
+### リージョンコード { #region-code }
 
 * リージョンサービスはリージョンごとにエンドポイントアドレスが異なるため、`{region code}`に下記のリージョンコードを記入する必要があります。
 
@@ -13,7 +17,8 @@
 | 韓国(光州) | kr3 |
 | 日本(東京) | jp1 |
 
-### サービスゲートウェイ連動サービス
+<a id="service-gateway-integration-services"></a>
+### サービスゲートウェイ連動サービス { #service-gateway-integration-services }
 
 * 下記のサービスでサービスゲートウェイを作成すると、インターネットを経由せず、NHN Cloud内部ネットワークにアクセスできます。
     * サービスゲートを作成する方法は[Service Gateway > コンソール使用ガイド](/Network/Service%20Gateway/jp/console-guide/)をご参照ください。

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,10 +1,15 @@
-## Network > Service Gateway > 콘솔 사용 가이드
+<!-- pre-align:aligned sig=618efc96173d -->
+
+<a id="network-service-gateway-console-user-guide"></a>
+## Network > Service Gateway > 콘솔 사용 가이드 { #network-service-gateway-console-user-guide }
 
 콘솔에서 **Service Gateway** 서비스를 사용하는 방법을 설명합니다.
 
-## 서비스 게이트웨이
+<a id="service-gateway"></a>
+## 서비스 게이트웨이 { #service-gateway }
 
-### 서비스 게이트웨이 생성
+<a id="create-a-service-gateway"></a>
+### 서비스 게이트웨이 생성 { #create-a-service-gateway }
 
 서비스 게이트웨이를 생성하는 방법은 다음과 같습니다.
 
@@ -23,30 +28,36 @@
     * 생성 시에만 선택이 가능하며 변경은 지원하지 않습니다.
     > [참고] 선택이 가능한 서비스에서만 활성화됩니다.
 
-### 서비스 게이트웨이 조회
+<a id="view-a-service-gateway"></a>
+### 서비스 게이트웨이 조회 { #view-a-service-gateway }
 
 생성한 서비스 게이트웨이는 **Network > Service Gateway** 화면에서 확인할 수 있습니다. 서비스 게이트웨이를 선택하면 하단에 서비스 게이트웨이 정보가 나타납니다.
 
-### 서비스 게이트웨이 변경
+<a id="modify-a-service-gateway"></a>
+### 서비스 게이트웨이 변경 { #modify-a-service-gateway }
 
 서비스 게이트웨이를 변경하는 방법은 다음과 같습니다. **이름**, **설명**만 변경할 수 있습니다.
 
 1. **Network > Service Gateway**로 이동합니다.
 2. **서비스 게이트웨이 변경** 버튼을 클릭한 후 변경 화면에서 원하는 항목을 변경합니다.
 
-### 서비스 게이트웨이 삭제
+<a id="delete-a-service-gateway"></a>
+### 서비스 게이트웨이 삭제 { #delete-a-service-gateway }
 
 서비스 게이트웨이를 삭제하려면 **Network > Service Gateway** 화면에서 삭제할 서비스 게이트웨이를 선택하고 **서비스 게이트웨이 삭제** 버튼을 클릭합니다.
 
-## 서비스 게이트웨이 사용
+<a id="use-a-service-gateway"></a>
+## 서비스 게이트웨이 사용 { #use-a-service-gateway }
 
-### 서비스 게이트웨이 IP확인
+<a id="check-the-service-gateway-ip"></a>
+### 서비스 게이트웨이 IP확인 { #check-the-service-gateway-ip }
 
 1. **Network > Service Gateway**로 이동합니다.
 2. 서비스 게이트웨이 목록에서 **IP 주소**를 확인합니다.<br>
    이 VM Instance에서 이 IP 주소로 접속 시 서비스 게이트웨이가 연결하고 있는 서비스로 연결됩니다.
 
-### 서비스 게이트웨이 접속
+<a id="connect-to-the-service-gateway"></a>
+### 서비스 게이트웨이 접속 { #connect-to-the-service-gateway }
 
 생성된 서비스 게이트웨이의 IP 주소가 `192.168.1.42`라 할 경우 다음과 같은 방법으로 서비스에 접근이 가능합니다.
 
@@ -67,11 +78,13 @@
 
             ~# wget https://kr1-api-object-storage.nhncloudservice.com/v1/AUTH_8222a22c22244badbf876dcd521f3f98/test-obs/test_file.txt
 
-## 서비스 게이트웨이에서 오브젝트 스토리지 사용 예제
+<a id="example-of-using-object-storage-from-a-service-gateway"></a>
+## 서비스 게이트웨이에서 오브젝트 스토리지 사용 예제 { #example-of-using-object-storage-from-a-service-gateway }
 
 **오브젝트 스토리지**에 관련된 내용은 예제 설명을 위한 수준에서만 기술합니다. 오브젝트 스토리지의 자세한 사용 방법은 **사용자 가이드 > Storage > Oject Storage**를 참고하시기 바랍니다.
 
-### 서비스 게이트웨이 생성
+<a id="example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway"></a>
+### 서비스 게이트웨이 생성 { #example-of-using-object-storage-from-a-service-gateway-create-a-service-gateway }
 
 **오브젝트 스토리지 API**를 사용하려면 **인증 토큰**을 발급받아야 합니다. 인터넷 사용이 불가능한 격리된 환경의 VPC에서 Object Storage를 사용하려면 인증 토큰도 서비스 게이트웨이를 이용하여 발급받아야 하며, 다음 절차에 따라서 서비스 게이트웨이를 생성해야 합니다.
 
@@ -81,7 +94,8 @@
    인증 토큰(token) 발급을 위한 서비스 게이트웨이입니다.
 3. 생성된 두 개의 서비스 게이트웨이에서 IP 주소를 확인합니다.
 
-### /etc/hosts 파일 편집
+<a id="edit-the-etchosts-file"></a>
+### /etc/hosts 파일 편집 { #edit-the-etchosts-file }
 
 **Object Storage**를 선택하여 생성한 서비스 게이트웨이의 IP 주소가 192.168.1.42이고 **IaaS API Identity**를 선택하여 생성한 서비스 게이트웨이의 IP 주소로 192.168.1.57을 할당받은 경우, VM Instance의 `/etc/hosts` 파일에 아래와 같이 IP 주소와 URL을 추가합니다.
 
@@ -93,7 +107,8 @@
 192.168.1.57	kr1-api-object-storage.nhncloudservice.com
 ```
 
-### 인증 토큰 발급
+<a id="obtain-the-authentication-token"></a>
+### 인증 토큰 발급 { #obtain-the-authentication-token }
 
 오브젝트 스토리지의 **API 비밀번호 설정**을 하고 인증 토큰을 발급받습니다.
 
@@ -115,7 +130,8 @@
 
             {"access":{"token":{"id":"gAAAAABiVnmCOJVJhh1W2eXGo3aL0eaZxXmd-SMDMIE3zmip2lXy6eH0BlZAlTZBG20dWEm7TF4zi4YIOTKnc6yKh_wqZsyxgMWKkpVNShzE-k6GaSThBP54QeUePSjC2t-R10X6G4xL_Wecl-V-lV-bnOfVo6Ccpz6rv9eLYJnbJw7KrIMSSiY","expires":"2022-04-13T19:19:30Z","tenant":{"id":"2fda9d4b8821111192ff23841198e2e6","name":"tTMgSSSF","groupId":"XXj2zkH7777modGU","description":"","enabled":true,"project_domain":"NORMAL","swift":true},"issued_at":"2022-04-13T07:32:14.000441"},"serviceCatalog":[{"endpoints":[{"region":"KR1","publicURL":"https://api-identity.infrastructure.cloud.toast.com/v2.0"}],"type":"identity","name":"keystone"},{"endpoints":[{"region":"KR2","publicURL":"https://kr2-api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"},{"region":"KR1","publicURL":"https://api-storage.cloud.toast.com/v1/AUTH_2fda9d4b88244a0a92ff23841198e2e6"}],"type":"object-store","name":"swift"}],"user":{"id":"80884888887b45dbaf9b815117130671","username":"5111111c-b111-4b11-b11b-01111f81111f","name":"5211122c-bfc4-4115-b11b-05b52f84
 
-### 오브젝트 스토리지 API 사용
+<a id="use-the-object-storage-api"></a>
+### 오브젝트 스토리지 API 사용 { #use-the-object-storage-api }
 
 인증 토큰 발급을 마쳤으면 오브젝트 스토리지 API를 사용할 수 있습니다. 오브젝트 스토리지에 example이라는 컨테이너를 생성하고 test_file.txt를 넣어 놨다고 가정할 경우, 아래와 같은 API 사용법으로 컨테이너에 있는 파일을 조회할 수 있습니다.
 

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,8 +1,12 @@
-## Network > Service Gateway > 개요
+<!-- pre-align:aligned sig=321428a4bf12 -->
+
+<a id="network-service-gateway-overview"></a>
+## Network > Service Gateway > 개요 { #network-service-gateway-overview }
 
 **Service Gateway** 서비스를 이용하면 **플로팅 IP**를 쓰지 않고 트래픽이 인터넷을 경유하지 않고도 **VPC** 외부의 NHN Cloud의 **서비스**를 이용할 수 있습니다. **서비스 게이트웨이 생성** 시 선택된 **서비스**와 자동으로 할당된 IP는 1:1 연결 관계를 유지하며, **VPC**에서는 **서비스 게이트웨이**의 IP를 이용하여 NHN Cloud의 내부 네트워크를 경유해 대상 **서비스**를 안전하게 이용할 수 있습니다.
 
-### 주요 기능
+<a id="main-features"></a>
+### 주요 기능 { #main-features }
 
 * VPC에서 인터넷을 경유하지 않고 서비스 게이트웨이에서 제공하는 NHN Cloud의 서비스에 연결할 수 있습니다.
 * 서비스 게이트웨이 생성 시 서비스 목록에 제공되는 서비스만 이용이 가능합니다.
@@ -10,7 +14,8 @@
 * VPC의 VM Instance에서 서비스 게이트웨이의 IP 주소로 통신 시 서비스 게이트웨이와 연결된 서비스와 통신됩니다.
 * 현재는 한국(판교), 한국(평촌) 리전에만 제공됩니다. 점차 다른 리전도 지원할 예정입니다.
 
-### 제공 서비스
+<a id="provided-services"></a>
+### 제공 서비스 { #provided-services }
 
 VPC의 VM Instance에서 인터넷을 경유하지 않고 NHN Cloud의 서비스에 접근이 필요한 경우 서비스 게이트웨이에서 제공되는 서비스를 선택하여 서비스 게이트웨이를 생성합니다.
 자세한 사용 방법은 [Service Gateway > 콘솔 사용 가이드](/Network/Service%20Gateway/ko/console-guide/)를 참고하세요.

--- a/ko/public-api.md
+++ b/ko/public-api.md
@@ -1,5 +1,7 @@
+<!-- pre-align:aligned sig=0fdf7e57a581 -->
 
-## Network > Service Gateway > API v2 가이드
+<a id="network-service-gateway-api-v2-guide"></a>
+## Network > Service Gateway > API v2 가이드 { #network-service-gateway-api-v2-guide }
 
 NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토큰을 사용합니다. IaaS 토큰은 NHN Cloud의 OpenStack 기반 인프라 서비스(IaaS)에서 사용하는 인증 토큰입니다. IaaS 토큰 발급 및 사용에 대한 자세한 내용은 [IaaS 토큰](/nhncloud/ko/public-api/iaas-token)을 참고하세요.
 
@@ -11,15 +13,18 @@ NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토�
 
 API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니다. 이런 필드는 NHN Cloud 내부 용도로 사용되며 사전 공지 없이 변경될 수 있으므로 사용하지 않습니다.
 
-## 서비스 게이트웨이
+<a id="service-gateway"></a>
+## 서비스 게이트웨이 { #service-gateway }
 
-### 서비스 게이트웨이 목록 보기
+<a id="get-a-list-of-service-gateways"></a>
+### 서비스 게이트웨이 목록 보기 { #get-a-list-of-service-gateways }
 
 ```
 GET /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-list-of-service-gateways-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -36,6 +41,7 @@ X-Auth-Token: {tokenId}
 | include_gateway_identity| Query | Boolean | - | NAT IP 주소 고정 사용 여부 |
 
 
+<a id="get-a-list-of-service-gateways-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -78,13 +84,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### 서비스 게이트웨이 보기
+<a id="get-a-service-gateway"></a>
+### 서비스 게이트웨이 보기 { #get-a-service-gateway }
 
 ```
 GET /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-service-gateway-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -93,6 +101,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | serviceGatewayId | URL | UUID | O | 서비스 게이트웨이 ID |
 
+<a id="get-a-service-gateway-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -140,13 +149,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### 서비스 게이트웨이 생성하기
+<a id="create-a-service-gateway"></a>
+### 서비스 게이트웨이 생성하기 { #create-a-service-gateway }
 
 ```
 POST /v2.0/gateways/servicegateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-service-gateway-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -180,6 +191,7 @@ X-Auth-Token: {tokenId}
 ```
 </details>
 
+<a id="create-a-service-gateway-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -228,13 +240,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### 서비스 게이트웨이 수정하기
+<a id="modify-a-service-gateway"></a>
+### 서비스 게이트웨이 수정하기 { #modify-a-service-gateway }
 
 ```
 PUT /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modify-a-service-gateway-request"></a>
 #### 요청
 
 | 이름 | 종류 | 형식 | 필수 | 설명 |
@@ -257,6 +271,7 @@ X-Auth-Token: {tokenId}
 ```
 </details>
 
+<a id="modify-a-service-gateway-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -305,13 +320,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### 서비스 게이트웨이 삭제하기
+<a id="delete-a-service-gateway"></a>
+### 서비스 게이트웨이 삭제하기 { #delete-a-service-gateway }
 
 ```
 DELETE /v2.0/gateways/servicegateways/{serviceGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-service-gateway-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -321,6 +338,7 @@ X-Auth-Token: {tokenId}
 | serviceGatewayId | URL | UUID | O | 서비스 게이트웨이 ID |
 
 
+<a id="delete-a-service-gateway-response"></a>
 #### 응답
 이 API는 응답 본문을 반환하지 않습니다.
 
@@ -333,15 +351,18 @@ X-Auth-Token: {tokenId}
 
 
 
-## 서비스 엔드포인트
+<a id="service-endpoint"></a>
+## 서비스 엔드포인트 { #service-endpoint }
 
-### 서비스 엔드포인트 목록 보기
+<a id="get-a-list-of-service-endpoints"></a>
+### 서비스 엔드포인트 목록 보기 { #get-a-list-of-service-endpoints }
 
 ```
 GET /v2.0/gateways/serviceendpoints/
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-list-of-service-endpoints-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -353,6 +374,7 @@ X-Auth-Token: {tokenId}
 
 
 
+<a id="get-a-list-of-service-endpoints-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |
@@ -381,13 +403,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### 서비스 엔드포인트 보기
+<a id="get-a-service-endpoint"></a>
+### 서비스 엔드포인트 보기 { #get-a-service-endpoint }
 
 ```
 GET /v2.0/gateways/serviceendpoints/{seerviceEndpointId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="get-a-service-endpoint-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -396,6 +420,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID |
 | serviceEndpointId | URL | UUID | O | 서비스 엔드포인트 ID |
 
+<a id="get-a-service-endpoint-response"></a>
 #### 응답
 
 | 이름 | 종류 | 형식 | 설명 |

--- a/ko/service-endpoint.md
+++ b/ko/service-endpoint.md
@@ -1,8 +1,12 @@
-## Network > Service Gateway > 서비스 엔드포인트
+<!-- pre-align:aligned sig=1d1c35e9431e -->
+
+<a id="network-service-gateway-service-endpoint"></a>
+## Network > Service Gateway > 서비스 엔드포인트 { #network-service-gateway-service-endpoint }
 
 서비스 게이트웨이를 이용하여 NHN Cloud 내부 네트워크로 통신할 수 있는 서비스 목록 및 각 서비스별 엔드포인트입니다.
 
-### 리전 코드
+<a id="region-code"></a>
+### 리전 코드 { #region-code }
 
 * 리전 서비스는 각 리전별로 엔드포인트 주소가 다르므로 `{region code}`에 아래의 리전 코드를 기입해야 합니다.
 
@@ -13,7 +17,8 @@
 | 한국(광주) | kr3 |
 | 일본(도쿄) | jp1 |
 
-### 서비스 게이트웨이 연동 서비스
+<a id="service-gateway-integration-services"></a>
+### 서비스 게이트웨이 연동 서비스 { #service-gateway-integration-services }
 
 * 아래 서비스로 서비스 게이트웨이를 생성하면 인터넷을 경유하지 않고, NHN Cloud 내부 네트워크로 접근할 수 있습니다.
     * 서비스 게이트웨이를 생성하는 방법은 [Service Gateway > 콘솔 사용 가이드](/Network/Service%20Gateway/ko/console-guide/)를 참고하세요.


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `beta` |
| Scope | 4 doc(s) scanned · 12 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/116/ |
| Generated | 2026-07-11T14:39:04 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`beta`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FService-Gateway%2Ftree%2Fbeta&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FService-Gateway%2Fpull%2F76&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FService-Gateway%2Fpull%2F76&ref=beta&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/service-endpoint.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/service-endpoint.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/service-endpoint.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/Service-Gateway`